### PR TITLE
Use automatic anchor for Scripts in io-flags.adoc

### DIFF
--- a/src/usage/io-flags.adoc
+++ b/src/usage/io-flags.adoc
@@ -7,10 +7,9 @@ If you want to read multiple EDN values, use the `-I` flag. The `-o`
 option prints the result as lines of text. The `-O` option prints the
 result as lines of EDN values.
 
-____
-*Note:* `*input*` is only available in the `user` namespace, designed
-for one-liners. For writing scripts, see link:#scripts[scripts].
-____
+NOTE: `*input*` is only available in the `user` namespace, designed
+for one-liners. For writing scripts, see <<_scripts>>.
+
 
 The following table illustrates the combination of options for commands
 of the form


### PR DESCRIPTION
This patch fixes the reference to Scripts in the note and also use the `NOTE:` admonition for it -
which looks way better in the rendered doc.

For details on the `<<_scripts>>` syntax check: https://docs.asciidoctor.org/asciidoc/latest/macros/xref