### PR TITLE
Add a few things to task docs

### DIFF
--- a/.license-assignments/rwstauner.md
+++ b/.license-assignments/rwstauner.md
@@ -1,0 +1,6 @@
+By placing this file I hereby grant Michiel Borkent and his successors, assigns,
+and sublicensees, a non-exclusive license to copy, reproduce, print, publish,
+distribute, translate, and otherwise use all work, code, or works of authorship
+produced and contributed to this project in all versions and editions of the
+Work, and in any works based on or incorporating the Work, in any and all media,
+in perpetuity and throughout the world.

--- a/src/tasks.adoc
+++ b/src/tasks.adoc
@@ -162,7 +162,7 @@ Entering: print-env
 1
 ----
 
-The `:leave` hook is similar to `:enter` but it executed after each task.
+The `:leave` hook is similar to `:enter` but is executed after each task.
 
 Both hooks can be overriden as task-local options. Setting them to `nil` will
 disable them for specific tasks.
@@ -213,7 +213,7 @@ task expression should then be moved to the `:task` key:
  }
 ----
 
-A task support the `:doc` option which gives it a docstring which is printed
+Tasks support the `:doc` option which gives it a docstring which is printed
 when invoking `bb tasks` on the command line. Other options include:
 
 - `:requires`: task-specific namespace requires.

--- a/src/tasks.adoc
+++ b/src/tasks.adoc
@@ -558,6 +558,7 @@ expressions. Most notably:
 
 - You cannot use `#(foo %)`, but you can use `(fn [x] (foo x))`
 - You cannot use `@(foo)` but you can use `(deref foo)`
+- You cannot use `#"re"` but you can use `(re-pattern "re")`
 - Single quotes are accidentally supported in some places, but are better
   avoided: `{:task '(foo)}` does not work, but `{:task (quote (foo))` does
   work. When requiring namespaces, use the `:requires` feature in favor of doing

--- a/src/tasks.adoc
+++ b/src/tasks.adoc
@@ -523,6 +523,7 @@ at Doctor Evidence]
 * https://github.com/redstarssystems/rssyslib/blob/develop/bb.edn[rssyslib]
 * https://github.com/clj-commons/rewrite-clj/blob/main/bb.edn[rewrite-clj]
 * https://gist.github.com/delyada/9f50fa7466358e55f27e4e6b4314242f
+* https://github.com/rwstauner/jirazzz/blob/main/bb.edn[jirazzz]
 
 === Naming
 

--- a/src/tasks.adoc
+++ b/src/tasks.adoc
@@ -165,7 +165,7 @@ Entering: print-env
 The `:leave` hook is similar to `:enter` but is executed after each task.
 
 Both hooks can be overriden as task-local options. Setting them to `nil` will
-disable them for specific tasks.
+disable them for specific tasks (see <<_task_local_options>>).
 
 === Command line arguments
 


### PR DESCRIPTION
- Add license assignment for rwstauner
- Fix typos
- Link to task-local-options when referring to disabling hooks
- Mention that re-pattern can be used where #"" cannot
- Add jirazzz to real world task use examples

Let me know if there's anything here you don't want or would like changed.
Thanks!