### PR TITLE
fixed reversed return value in example

### DIFF
--- a/src/usage.adoc
+++ b/src/usage.adoc
@@ -418,7 +418,7 @@ $ bb -e "#?(:bb :hello :clj :bye)"
 :hello
 
 $ bb -e "#?(:clj :bye :bb :hello)"
-:bye
+:hello
 
 $ bb -e "[1 2 #?@(:bb [] :clj [1])]"
 [1 2]


### PR DESCRIPTION
`bb -e "#?(:clj :bye :bb :hello)"`
should be returning the code executed in the `:bb` section, but the example has it returning the value from the `:clj` section