### PR TITLE
Add recipe for REPL safe scripts

### DIFF
--- a/src/recipes.adoc
+++ b/src/recipes.adoc
@@ -57,6 +57,24 @@ be implemented with:
 (= *file* (System/getProperty "babashka.file"))
 ----
 
+Combining this with a conditional invocation of `-main` creates a script file that is safe to load at a REPL, and easy to invoke at the CLI.
+
+[source,clojure]
+---
+#!/usr/bin/env bb
+
+;; Various functions defined here
+
+(defn -main [& args]
+;; Implementation of main
+)
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))
+---
+
+This can be exceedingly handy for complex writing complex scripts while not being able to adjust how they are invoked by other tools.
+
 === Shutdown hook
 
 Adding a shutdown hook allows you to execute some code before the script


### PR DESCRIPTION
After a [conversation](https://clojurians.slack.com/archives/CLX41ASCS/p1660599920869789) on Slack, I put the advice I'd gained into an example for the docs.

This shows how to create a shebang based script that can also be loaded safely into the REPL.