### PR TITLE
A random port can be used for any of the REPL servers

### DIFF
--- a/src/usage/repl.adoc
+++ b/src/usage/repl.adoc
@@ -167,3 +167,7 @@ $ git clone https://github.com/borkdude/babashka --recurse-submodules
 $ cd babashka
 $ BABASHKA_DEV=true clojure -A:main --nrepl-server 1667
 ----
+
+==== REPL server port
+
+For the socket REPL, pREPL, or nREPL, if a randomized port is needed, 0 can be used anywhere a port argument is accepted.


### PR DESCRIPTION
https://github.com/babashka/babashka/issues/1429

I wasn't sure where to put the text. Maybe right after "Babashka supports running a REPL, a socket REPL and an nREPL server." is better, without creating a new section?