### PR TITLE
use --prn when running the sample script

### DIFF
--- a/src/getting_started.adoc
+++ b/src/getting_started.adoc
@@ -45,7 +45,7 @@ or run a script:
 
 [source,clojure]
 ----
-$ bb -f script.clj
+$ bb --prn -f script.clj
 6
 ----
 
@@ -61,7 +61,7 @@ Similarly, the `-f` flag is optional when the argument is a filename:
 
 [source,clojure]
 ----
-$ bb script.clj
+$ bb --prn script.clj
 6
 ----
 


### PR DESCRIPTION
the current version (v1.1.172) does not print anything when running script.clj unless the --prn opt is used - Tested on both Windows and Linux.