### PR TITLE
Update missing brackets in usage

### DIFF
--- a/src/usage.adoc
+++ b/src/usage.adoc
@@ -83,7 +83,7 @@ https://github.com/babashka/cli[`babashka.cli`] namespace:
 (require '[babashka.cli :as cli])
 
 (def cli-options {:port {:default 80 :coerce :long}
-                  :help {:coerce :boolean}
+                  :help {:coerce :boolean}})
 
 (prn (:options (cli/parse-opts *command-line-args* {:spec cli-options})))
 ----

--- a/src/usage.adoc
+++ b/src/usage.adoc
@@ -85,7 +85,7 @@ https://github.com/babashka/cli[`babashka.cli`] namespace:
 (def cli-options {:port {:default 80 :coerce :long}
                   :help {:coerce :boolean}})
 
-(prn (:options (cli/parse-opts *command-line-args* {:spec cli-options})))
+(prn (cli/parse-opts *command-line-args* {:spec cli-options}))
 ----
 
 [source,bash]


### PR DESCRIPTION
Couple of minor changes under `Usage`.

Tested on a new version of `bb` and it doesn't seem to be backwards compatible, but feel free to correct these corrections :) 