### PR TITLE
Update usage.adoc

### DIFF
--- a/src/usage.adoc
+++ b/src/usage.adoc
@@ -263,7 +263,7 @@ Producing an uberscript with all required code:
 
 [source,bash]
 ----
-$ bb uberscript glob-uberscript.clj -f glob.clj
+$ bb uberscript glob-uberscript.clj glob.clj
 ----
 
 To prove that we don't need the classpath anymore:


### PR DESCRIPTION
In v1.3.180 '-f' gives an error:

$ bb uberscript glob-uberscript.clj -f glob.clj
----- Error --------------------------------------------------------------------
Type:     java.lang.Exception
Message:  File does not exist: -f