### PR TITLE
Mention clojure.walk in namespaces section

### DIFF
--- a/src/libraries.adoc
+++ b/src/libraries.adoc
@@ -32,6 +32,7 @@ From Clojure:
 * `clojure.string` aliased as `str`
 * `clojure.stacktrace`
 * `clojure.test`
+* `clojure.walk`
 * `clojure.zip`
 
 Additional libraries:


### PR DESCRIPTION
I genuinely thought I wouldn't be able to access `clojure.walk` because it wasn't mentioned in the documentation.
This should take care that others aren't confused :) 