### PR TITLE
Add example for executing scripts with filename only

### DIFF
--- a/src/getting_started.adoc
+++ b/src/getting_started.adoc
@@ -67,6 +67,12 @@ $ bb script.clj
 
 Commonly, scripts have shebangs so you can invoke them with their filename only:
 
+[source,clojure]
+----
+$ ./script.clj
+6
+----
+
 .script.clj
 [source,clojure]
 ----


### PR DESCRIPTION
I believe having an example that shows how to execute scripts using only the filename would enhance understanding.