### PR TITLE
Update two library names in libraries.adoc

### DIFF
--- a/src/libraries.adoc
+++ b/src/libraries.adoc
@@ -72,8 +72,8 @@ as `transit`
 * https://github.com/yogthos/Selmer[`Selmer`]:
  - `selmer.parser`
 * https://github.com/clojure/tools.logging[`clojure.tools.logging`]
-* https://github.com/ptaoussanis/timbre[`timbre`]: logging
-* https://github.com/borkdude/edamame[`edamame`]: Clojure parser
+* https://github.com/ptaoussanis/timbre[`taoensso.timbre`]: logging
+* https://github.com/borkdude/edamame[`edamame.core`]: Clojure parser
 * https://github.com/clojure/core.rrb-vector[`core.rrb-vector`]
 
 Check out the https://babashka.org/toolbox/[babashka toolbox] and


### PR DESCRIPTION
The original names cannot be directly `require`d in babashka v1.12.195. For example, `(require '[timbre])` would throw `java.io.FileNotFoundException: Could not locate timbre.bb, timbre.clj or timbre.cljc on classpath. [at <repl>:1:1]`. And `(require '[taoensso.timbre])` is the working one.

This small change might help Clojure/babashka beginners (like me) a little bit :)